### PR TITLE
Resize datatables when page width changes

### DIFF
--- a/levels/index.html
+++ b/levels/index.html
@@ -509,7 +509,7 @@ getData()
 </form>
 <div class="btn btn-block btn-info"><div id="refresh" title='Get new data from the sheet. Useful if you just submitted a clear'>Refresh Data <i class="fa fa-refresh" aria-hidden="true"></i></div></div>
 
-<table id="table" class="compact row-border stripe hover">
+<table id="table" class="compact row-border stripe hover" style="width:100%">
   <thead><tr>
     <th style="width:10px;">No.</th>
     <th style="width:10em;">Level Code</th>

--- a/members/index.html
+++ b/members/index.html
@@ -430,7 +430,7 @@ getData()
 
   
 
-<table id="table" class="compact row-border stripe hover">
+<table id="table" class="compact row-border stripe hover" style="width:100%">
   <thead><tr>
     <th>Member Name</th>
     <th>Shelder</th>


### PR DESCRIPTION
Datatables are set to fixed width upon page load in the style tag. This patch will make it so the tables will resize themselves if the page size changes as well. Unfortunately you have to use the style tag for this as opposed to a css rule.